### PR TITLE
Devpass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+test/test_binaries/
+
 # C extensions
 *.so
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Since we use the `runsolver` to limit resources, the generic wrapper can only be
 
 ## Examples
 
-Please see `./examples/` for some examples with black box functions (no problem instances included) and examples of algorithms with problem instances (i.e., SAT solving). 
+Please see `./examples/` for some examples with black box functions (no problem instances included) and examples of algorithms with problem instances (i.e., SAT solving).
+Each example comes with its own README with further details.
 
 We provide a more extensive tutorial for "How to write your own Wrapper" with using the GenericWrapper [here](http://aclib.net/smac/tutorial/genericwrapper/).
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ and which also installs all dependencies (including `runsolver`).
 
 ```
 python setup.py install
+
+# To test installation run afterwards
+python setup.py test
 ```
 
 ## USAGE

--- a/examples/MiniSAT/MiniSATWrapper.py
+++ b/examples/MiniSAT/MiniSATWrapper.py
@@ -1,3 +1,5 @@
+import os
+
 def get_command_line_cmd(runargs, config):
     '''
     @contact:    lindauer@informatik.uni-freiburg.de, fh@informatik.uni-freiburg.de
@@ -15,7 +17,7 @@ def get_command_line_cmd(runargs, config):
     Returns:
         A command call list to execute the target algorithm.
     '''
-    solver_binary = "examples/MiniSAT/minisat"
+    solver_binary = os.path.join(os.path.dirname(__file__), "minisat")
     cmd = "%s -rnd-seed=%d" %(solver_binary, runargs["seed"])       
     for name, value in config.items():
         cmd += " %s=%s" %(name,  value)

--- a/examples/SGD/README.md
+++ b/examples/SGD/README.md
@@ -1,8 +1,8 @@
 #Wrapper for SGD
 
-This is a more advanced example for optimizing a black box function (here SGD on a fixed data set).
+This is a more advanced example for optimizing a black box function (here SGD on a fixed data set) which has an additional requirement: scikit-learn.
 
-The target algorithm is a simple python script `sgd_ta.py` which loads the iris data set from sklearn, reads the parameter configuration, fits a SGD classifier and prints the accuracy on a holdout set.
+The target algorithm is a simple python script `sgd_ta.py` which loads the iris data set from scikit-learn, reads the parameter configuration, fits a SGD classifier and prints the accuracy on a holdout set.
 
 The script supports three kind of "instances":
 

--- a/examples/SGD/SGDWrapper.py
+++ b/examples/SGD/SGDWrapper.py
@@ -68,6 +68,11 @@ class SGDWrapper(AbstractWrapper):
         '''
         
         self.logger.debug("reading solver results from %s" % (filepointer.name))
+
+        # If solver result file is empty, we also assume a crash
+        resultMap = {'status': 'CRASHED',
+                     'quality': 1  # assumption minimization
+                     }
         for line in filepointer:
             try:
                 out_ = str(line.decode('UTF-8')).replace("\n","")
@@ -77,9 +82,7 @@ class SGDWrapper(AbstractWrapper):
                  }
                 return resultMap
             except ValueError:
-                resultMap = {'status' : 'CRASHED',
-                 'quality' : 1 # assumption minimization
-                 }
+                pass
 
         return resultMap
 

--- a/genericWrapper4AC/generic_wrapper.py
+++ b/genericWrapper4AC/generic_wrapper.py
@@ -134,7 +134,7 @@ class AbstractWrapper(object):
             elif 'misc' in resultMap:
                 self.data.additional += "; " + resultMap['misc']
 
-            # if quality is still set to 2**32 - 1 and we use the new fromat,
+            # if quality is still set to 2**32 - 1 and we use the new format,
             # overwrite quality with runtime, since irace only looks at the
             # cost field
             if self.data.new_format and self.data.cost == 2**32 - 1:

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setuptools.setup(
     name='GenericWrapper4AC',
     description='Generic Wrapper to interface between algorithm configurators and algorithms to tune',
     version='2.0.0',
+    python_requires='>=3.5',
     packages=setuptools.find_packages(exclude=['test']),
     test_suite='nose.collector',
     tests_require=["nose", "scikit-learn"],

--- a/setup.py
+++ b/setup.py
@@ -6,32 +6,21 @@ import traceback
 import setuptools
 from setuptools.command.install import install
 
-RUNSOLVER_LOCATION = 'runsolver/runsolver-3.3.4-patched/src/'
-DOWNLOAD_DIRECTORY = os.path.join(os.path.dirname(__file__), '.downloads/')
+RUNSOLVER_LOCATION = os.path.join(os.path.dirname(__file__), 'runsolver',
+                                  'runsolver-3.3.4-patched', 'src')
 BINARIES_DIRECTORY = 'genericWrapper4AC/binaries'
+TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), 'test',
+                              'test_binaries')
+
 
 class InstallRunsolver(install):
 
     def run(self):
-        try:
-            shutil.rmtree(DOWNLOAD_DIRECTORY)
-        except Exception:
-            #traceback.print_exc()
-            pass
-
-        try:
-            os.makedirs(DOWNLOAD_DIRECTORY)
-        except Exception:
-            #traceback.print_exc()
-            pass
-
-        shutil.copytree(RUNSOLVER_LOCATION,os.path.join(DOWNLOAD_DIRECTORY,"runsolver"))
-        runsolver_source_path = os.path.join(DOWNLOAD_DIRECTORY,"runsolver")
-
         # Build the runsolver
         sys.stdout.write('Building runsolver\n')
         cur_pwd = os.getcwd()
-        os.chdir(runsolver_source_path)
+        print(cur_pwd)
+        os.chdir(RUNSOLVER_LOCATION)
         subprocess.check_call('make')
         os.chdir(cur_pwd)
 
@@ -46,9 +35,18 @@ class InstallRunsolver(install):
         except Exception:
             pass
 
+        # Copy the runsolver into the test directory so tests can be run
+        try:
+            os.makedirs(TEST_DIRECTORY)
+        except Exception:
+            pass
+        shutil.copy(os.path.join(RUNSOLVER_LOCATION, 'runsolver'),
+                        os.path.join(TEST_DIRECTORY, 'runsolver'))
+
         # Copy the runsolver into the sources so it gets copied
-        shutil.move(os.path.join(runsolver_source_path, 'runsolver'),
+        shutil.move(os.path.join(RUNSOLVER_LOCATION, 'runsolver'),
                     os.path.join(BINARIES_DIRECTORY, 'runsolver'))
+
 
         #install.do_egg_install(self)
         install.run(self)
@@ -57,19 +55,15 @@ class InstallRunsolver(install):
             shutil.rmtree(BINARIES_DIRECTORY)
         except OSError:
             pass
-        try:
-            shutil.rmtree(DOWNLOAD_DIRECTORY)
-        except OSError:
-            pass
+
 
 setuptools.setup(
     name='GenericWrapper4AC',
     description='Generic Wrapper to interface between algorithm configurators and algorithms to tune',
     version='2.0.0',
     python_requires='>=3.5',
-    packages=setuptools.find_packages(exclude=['test']),
     test_suite='nose.collector',
-    tests_require=["nose", "scikit-learn"],
+    tests_require=["nose", "numpy", "scipy", "scikit-learn"],
     cmdclass={'install': InstallRunsolver},
     include_package_data=True,
     package_data={"genericWrapper4AC": ["binaries/runsolver"]},

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setuptools.setup(
     version='2.0.0',
     packages=setuptools.find_packages(exclude=['test']),
     test_suite='nose.collector',
+    tests_require=["nose", "scikit-learn"],
     cmdclass={'install': InstallRunsolver},
     include_package_data=True,
     package_data={"genericWrapper4AC": ["binaries/runsolver"]},

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class InstallRunsolver(install):
         # Build the runsolver
         sys.stdout.write('Building runsolver\n')
         cur_pwd = os.getcwd()
-        print(cur_pwd)
+
         os.chdir(RUNSOLVER_LOCATION)
         subprocess.check_call('make')
         os.chdir(cur_pwd)

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,8 @@ class InstallRunsolver(install):
                         os.path.join(TEST_DIRECTORY, 'runsolver'))
 
         # Copy the runsolver into the sources so it gets copied
-        shutil.move(os.path.join(RUNSOLVER_LOCATION, 'runsolver'),
+        shutil.copy(os.path.join(RUNSOLVER_LOCATION, 'runsolver'),
                     os.path.join(BINARIES_DIRECTORY, 'runsolver'))
-
 
         #install.do_egg_install(self)
         install.run(self)

--- a/test/test_calls/test_calls.py
+++ b/test/test_calls/test_calls.py
@@ -6,13 +6,20 @@ import genericWrapper4AC
 from examples.MiniSAT.SATCSSCWrapper import SatCSSCWrapper
 from examples.SGD.SGDWrapper import SGDWrapper
 
+
 class TestCalls(unittest.TestCase):
+
+    def __init__(self):
+        self.runsolver = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "test_binaries", "runsolver")
 
     def test_minisat_old(self):
 
         wrapper = SatCSSCWrapper()
 
         sys.argv = "examples/MiniSAT/SATCSSCWrapper.py --script examples/MiniSAT/MiniSATWrapper.py examples/MiniSAT/gzip_vc1071.cnf SAT 10 0 42 -rnd-freq 0 -var-decay 0.001 -cla-decay 0.001 -gc-frac 0.000001 -rfirst 1000"
+        sys.argv += " --runsolver-path " + self.runsolver
         sys.argv = sys.argv.split(" ")
 
         wrapper.main(exit=False)
@@ -27,7 +34,8 @@ class TestCalls(unittest.TestCase):
 
         wrapper = SatCSSCWrapper()
 
-        sys.argv = "examples/MiniSAT/SATCSSCWrapper.py --script examples/MiniSAT/MiniSATWrapper.py --instance examples/MiniSAT/gzip_vc1071.cnf --cutoff 10 --seed 42 --config -rnd-freq 0 -var-decay 0.001 -cla-decay 0.001 -gc-frac 0.000001 -rfirst 1000"
+        sys.argv = "python examples/MiniSAT/SATCSSCWrapper.py --script examples/MiniSAT/MiniSATWrapper.py --instance examples/MiniSAT/gzip_vc1071.cnf --cutoff 10 --seed 42 --config -rnd-freq 0 -var-decay 0.001 -cla-decay 0.001 -gc-frac 0.000001 -rfirst 1000"
+        sys.argv += " --runsolver-path " + self.runsolver
         sys.argv = sys.argv.split(" ")
 
         wrapper.main(exit=False)
@@ -46,6 +54,7 @@ class TestCalls(unittest.TestCase):
         wrapper = SGDWrapper()
 
         sys.argv = "examples/SGD/SGDWrapper.py train 0 5 0 9 -learning_rate constant -eta0 1 -loss hinge -penalty l2 -alpha 0.0001 -learning_rate optimal -eta0 0.0 -n_iter 2"
+        sys.argv += " --runsolver-path " + self.runsolver
         sys.argv = sys.argv.split(" ")
 
         wrapper.main(exit=False)
@@ -65,6 +74,7 @@ class TestCalls(unittest.TestCase):
         wrapper = SGDWrapper()
 
         sys.argv = "examples/SGD/SGDWrapper.py --instance train --seed 9 --config -learning_rate constant -eta0 1 -loss hinge -penalty l2 -alpha 0.0001 -learning_rate optimal -eta0 0.0 -n_iter 2"
+        sys.argv += " --runsolver-path " + self.runsolver
         sys.argv = sys.argv.split(" ")
 
         wrapper.main(exit=False)

--- a/test/test_calls/test_calls.py
+++ b/test/test_calls/test_calls.py
@@ -9,10 +9,8 @@ from examples.SGD.SGDWrapper import SGDWrapper
 
 class TestCalls(unittest.TestCase):
 
-    def __init__(self):
-        self.runsolver = os.path.join(
-            os.path.dirname(os.path.dirname(__file__)),
-            "test_binaries", "runsolver")
+    runsolver = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                             "test_binaries", "runsolver")
 
     def test_minisat_old(self):
 

--- a/test/test_calls/test_calls.py
+++ b/test/test_calls/test_calls.py
@@ -2,15 +2,16 @@ import unittest
 import sys
 import os
 
-import genericWrapper4AC
 from examples.MiniSAT.SATCSSCWrapper import SatCSSCWrapper
 from examples.SGD.SGDWrapper import SGDWrapper
 
 
 class TestCalls(unittest.TestCase):
 
-    runsolver = os.path.join(os.path.dirname(os.path.dirname(__file__)),
-                             "test_binaries", "runsolver")
+    def setUp(self):
+        self.runsolver = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "test_binaries", "runsolver")
 
     def test_minisat_old(self):
 

--- a/test/test_resources/test_limits.py
+++ b/test/test_resources/test_limits.py
@@ -1,16 +1,16 @@
 import unittest
-import sys
 import os
 
-import genericWrapper4AC
 from genericWrapper4AC.generic_wrapper import AbstractWrapper
 from genericWrapper4AC.data.data import Data
 
 
 class TestResourceLimits(unittest.TestCase):
 
-    runsolver = os.path.join(os.path.dirname(os.path.dirname(__file__)),
-                             "test_binaries", "runsolver")
+    def setUp(self):
+        self.runsolver = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "test_binaries", "runsolver")
 
     def test_memlimit(self):
 

--- a/test/test_resources/test_limits.py
+++ b/test/test_resources/test_limits.py
@@ -9,10 +9,8 @@ from genericWrapper4AC.data.data import Data
 
 class TestResourceLimits(unittest.TestCase):
 
-    def __init__(self):
-        self.runsolver = os.path.join(
-            os.path.dirname(os.path.dirname(__file__)),
-            "test_binaries", "runsolver")
+    runsolver = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                             "test_binaries", "runsolver")
 
     def test_memlimit(self):
 

--- a/test/test_resources/test_limits.py
+++ b/test/test_resources/test_limits.py
@@ -7,7 +7,12 @@ from genericWrapper4AC.generic_wrapper import AbstractWrapper
 from genericWrapper4AC.data.data import Data
 
 
-class TestRessourceLimits(unittest.TestCase):
+class TestResourceLimits(unittest.TestCase):
+
+    def __init__(self):
+        self.runsolver = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "test_binaries", "runsolver")
 
     def test_memlimit(self):
 
@@ -17,8 +22,7 @@ class TestRessourceLimits(unittest.TestCase):
 
         wrapper.data = data
         data.tmp_dir = "."
-        data.runsolver = os.path.join(genericWrapper4AC.__path__[
-            0], "binaries", "runsolver")
+        data.runsolver = self.runsolver
         data.mem_limit = 50  # mb
         data.cutoff = 100000
 
@@ -44,8 +48,7 @@ class TestRessourceLimits(unittest.TestCase):
 
         wrapper.data = data
         data.tmp_dir = "."
-        data.runsolver = os.path.join(genericWrapper4AC.__path__[
-            0], "binaries", "runsolver")
+        data.runsolver = self.runsolver
         data.mem_limit = 500  # mb
         data.cutoff = 1
 
@@ -72,8 +75,7 @@ class TestRessourceLimits(unittest.TestCase):
 
         wrapper.data = data
         data.tmp_dir = "."
-        data.runsolver = os.path.join(genericWrapper4AC.__path__[
-            0], "binaries", "runsolver")
+        data.runsolver = self.runsolver
         data.mem_limit = 500  # mb
         data.cutoff = 5
 


### PR DESCRIPTION
Pass on unit-tests.

  * rm code that cp'd/mv'd runsolver in setup.py
  * require Python > 3.5 and test dependencies
  * make sure tests find runsolver by copying it to test_binaries during installation
  * fix SGDWrapper crash if runsolver file is empty
  * extend README

**NOTE:** test_limits/test_memlimit fails from time to time as the wrapper returns a TIMEOUT instead of CRASHED.