### PR TITLE
Use `runsolver -v` to fetch the basic run stats

### DIFF
--- a/test/test_resources/test_limits.py
+++ b/test/test_resources/test_limits.py
@@ -30,8 +30,10 @@ class TestResourceLimits(unittest.TestCase):
 
         wrapper.read_runsolver_output()
 
+        wrapper._values_file.close()
         wrapper._watcher_file.close()
         wrapper._solver_file.close()
+        os.remove(wrapper._values_file.name)
         os.remove(wrapper._watcher_file.name)
         os.remove(wrapper._solver_file.name)
 
@@ -60,8 +62,10 @@ class TestResourceLimits(unittest.TestCase):
         self.assertNotEqual(wrapper.data.additional,
                             " memory limit was exceeded")
 
+        wrapper._values_file.close()
         wrapper._watcher_file.close()
         wrapper._solver_file.close()
+        os.remove(wrapper._values_file.name)
         os.remove(wrapper._watcher_file.name)
         os.remove(wrapper._solver_file.name)
 
@@ -89,7 +93,9 @@ class TestResourceLimits(unittest.TestCase):
         self.assertNotEqual(wrapper.data.additional,
                             " memory limit was exceeded")
 
+        wrapper._values_file.close()
         wrapper._watcher_file.close()
         wrapper._solver_file.close()
+        os.remove(wrapper._values_file.name)
         os.remove(wrapper._watcher_file.name)
         os.remove(wrapper._solver_file.name)


### PR DESCRIPTION
`runsolver -v` stores the most relevant run information (namely timeout status, memout status, and CPU time) in an easy-to-parse format.
This pull request ensures that `AbstractWrapper` invokes `runsolver` with a `-v` output file specified and that the output file is parsed to determine the timeout status, memout status, and CPU time of the target command.

# Justification
In some cases in which `AbstractWrapper.main` is invoked from multiple processes in parallel and `runsolver` terminates the target command due to timeout, `runsolver` fails to output the whole watcher file, failing to output namely the line with the timeout status. Relying solely on `runsolver -w` yields an incorrect behavior in these cases. `runsolver -v` has been observed to output a complete file reliably in these cases. The advantage of using `runsolver -v` is that it allows `AbstractWrapper.main` to behave correctly in these cases.